### PR TITLE
Update Chinese.lang

### DIFF
--- a/chinese/Chinese.lang
+++ b/chinese/Chinese.lang
@@ -1838,7 +1838,7 @@
 	<string name="item.book-of-enlightenment.name">启蒙书</string>
 	<string name="item.book-of-enlightenment.desc">+ %exp%% 经验获取.</string>
 
-	<string name="item.boots-of-speed.name">速度鞋</string>
+	<string name="item.boots-of-speed.name">速度之靴</string>
 	<string name="item.boots-of-speed.desc">+ %mspeed% 移动速度.</string>
 
 	<string name="item.broad-sword.name">阔剑</string>
@@ -1847,7 +1847,7 @@
 	<string name="item.cape-of-withdrawal.name">撤退披肩</string>
 	<string name="item.cape-of-withdrawal.desc">被敌人击中时提升 %mspeed%% 移动速度，持续 %dur% 秒.</string>
 
-	<string name="item.circlet-of-willpower.name">毅力戒指</string>
+	<string name="item.circlet-of-willpower.name">坚毅之戒</string>
 	<string name="item.circlet-of-willpower.desc">当生命值低于 %health%% 时，降低 %scost%% 施法消耗.</string>
 
 	<string name="item.chainmail.name">锁子甲</string>
@@ -1883,13 +1883,13 @@
 	<string name="item.heavy-gauntlets.name">重铁手套</string>
 	<string name="item.heavy-gauntlets.desc">+ %health% 生命上限.</string>
 
-	<string name="item.lesser-sphere-of-life.name">小生命宝珠</string>
+	<string name="item.lesser-sphere-of-life.name">小型生命宝珠</string>
 	<string name="item.lesser-sphere-of-life.desc">连杀期间 + %hregen% 生命回复率.</string>
 
-	<string name="item.lesser-sphere-of-mana.name">小魔法宝珠</string>
+	<string name="item.lesser-sphere-of-mana.name">小型魔法宝珠</string>
 	<string name="item.lesser-sphere-of-mana.desc">连杀期间 + %mregen% 法力回复率.</string>
 
-	<string name="item.lesser-sphere-of-nova.name">小新星宝珠</string>
+	<string name="item.lesser-sphere-of-nova.name">小型新星宝珠</string>
 	<string name="item.lesser-sphere-of-nova.desc">连杀期间，向四周释放新星爆发冲击波，每秒一次，造成 %dmg% 魔法伤害.</string>
 
 	<string name="item.life-stone.name">生命之石</string>
@@ -1898,7 +1898,7 @@
 	<string name="item.mail-of-thorns.name">荆棘盔甲</string>
 	<string name="item.mail-of-thorns.desc">受到攻击时反弹 %return% 物理伤害.</string>
 
-	<string name="item.mage-robe.name">法袍</string>
+	<string name="item.mage-robe.name">法师长袍</string>
 	<string name="item.mage-robe.desc">+ %mana% 法力上限.</string>
 
 	<string name="item.mana-stone.name">魔法之石</string>
@@ -1946,13 +1946,13 @@
 	<string name="item.spell-book.name">符咒书</string>
 	<string name="item.spell-book.desc">+ %spell% 技能伤害.</string>
 
-	<string name="item.spiked-flail.name">链锤</string>
+	<string name="item.spiked-flail.name">钉刺链锤</string>
 	<string name="item.spiked-flail.desc">+ %dmg% 普攻附加物理伤害.</string>
 
 	<string name="item.steady-greaves.name">稳固胫甲</string>
 	<string name="item.steady-greaves.desc">+ %armor% 护甲\n+ %health% 生命上限.</string>
 
-	<string name="item.stiletto.name">匕首</string>
+	<string name="item.stiletto.name">刺客匕首</string>
 	<string name="item.stiletto.desc">物理伤害无视敌人 %pierce%% 护甲.</string>
 
 	<string name="item.sturdy-belt.name">坚固皮带</string>
@@ -1973,7 +1973,7 @@
 	<string name="item.adventurers-garb.name">冒险家服饰</string>
 	<string name="item.adventurers-garb.desc">+ %health% 生命上限\n+ %mana% 法力上限.</string>
 
-	<string name="item.apothecarys-mortar-pestle.name">药剂师的研钵和杵</string>
+	<string name="item.apothecarys-mortar-pestle.name">药剂师的钵杵</string>
 	<string name="item.apothecarys-mortar-pestle.desc">饮用药剂后，护甲和魔法抗性提升 %eff%%，持续 5 秒 .</string>
 
 	<string name="item.apothecarys-satchel.name">药剂师的背包</string>
@@ -2007,7 +2007,7 @@
 	<string name="item.fancy-plume.desc">商店将有更多的待售商品.</string>
 
 	<string name="item.frying-pan.name">绝地神锅</string>
-	<string name="item.frying-pan.desc"> 格挡背后 %arc% 度角内的远程攻击.</string>
+	<string name="item.frying-pan.desc">格挡背后 %arc% 度角内的远程攻击.</string>
 
 	<string name="item.full-plate-mail.name">全身铠甲</string>
 	<string name="item.full-plate-mail.desc">+ %armor% 护甲.</string>
@@ -2112,16 +2112,16 @@
 	<string name="item.earthsplitter.name">裂地者</string>
 	<string name="item.earthsplitter.desc">普通攻击击中敌人时，有 %chance%% 几率释放地裂，造成 %dmg% 物理伤害.</string>
 
-	<string name="item.flametongue.name">火焰之舌</string>
+	<string name="item.flametongue.name">火舌</string>
 	<string name="item.flametongue.desc">+ %dmg% 普攻附加魔法伤害.\n灼烧攻击到的敌人.</string>
 
 	<string name="item.frostbrand.name">霜印</string>
 	<string name="item.frostbrand.desc">+ %dmg% 普攻附加魔法伤害. \n冻结攻击到的敌人.</string>
 
-	<string name="item.greater-sphere-of-nova.name">大新星宝珠</string>
+	<string name="item.greater-sphere-of-nova.name">大型新星宝珠</string>
 	<string name="item.greater-sphere-of-nova.desc">连杀期间，向四周释放更强大的新星爆发冲击波，每秒一次，造成 %dmg% 魔法伤害.</string>
 
-	<string name="item.greater-sphere-of-regen.name">大生命宝珠</string>
+	<string name="item.greater-sphere-of-regen.name">大型生命宝珠</string>
 	<string name="item.greater-sphere-of-regen.desc">连杀期间 + %hregen% 生命回复， + %mregen% 法力回复.</string>
 
 	<string name="item.heartseeker.name">觅心者</string>
@@ -2197,7 +2197,7 @@
 	<!-- SETS -->
 
 
-	<string name="item.sets.fire-and-ice.name">冰与火</string>
+	<string name="item.sets.fire-and-ice.name">寒冰烈火</string>
 	<string name="item.sets.fire-and-ice.desc">+ %dmg% 普攻附加魔法伤害</string>
 
 	<string name="item.sets.stones-of-midas.name">迈达斯之石</string>
@@ -2209,36 +2209,36 @@
 	<string name="item.sets.monster-encyclopedia.name">怪物图鉴</string>
 	<string name="item.sets.monster-encyclopedia.desc">+ %dmg%% 伤害</string>
 
-	<string name="item.sets.kings-regalia.name">国王套装</string>
+	<string name="item.sets.kings-regalia.name">王者华服</string>
 	<string name="item.sets.kings-regalia.desc">+ %speed%% 攻击速度 和 技能冷却速度 </string>
 
 	<string name="item.sets.apothecarys-implements.name">药剂师工具</string>
 	<string name="item.sets.apothecarys-implements.desc.1">+1 药剂使用次数</string>
 	<string name="item.sets.apothecarys-implements.desc.2">击杀敌人后有 %chance%% 几率补充药剂</string>
 
-	<string name="item.sets.journeymans-outfit.name">旅行者套装</string>
+	<string name="item.sets.journeymans-outfit.name">旅行装备</string>
 	<string name="item.sets.journeymans-outfit.desc.1">+ %armor% 护甲</string>
 	<string name="item.sets.journeymans-outfit.desc.2">+ %attack% 普攻伤害</string>
 	<string name="item.sets.journeymans-outfit.desc.3">受到的伤害降低 %reduction%% </string>
 
-	<string name="item.sets.disciples-arcana.name">学者的奥秘</string>
+	<string name="item.sets.disciples-arcana.name">信徒之秘</string>
 	<string name="item.sets.disciples-arcana.desc.1">+ %res% 魔法抗性</string>
 	<string name="item.sets.disciples-arcana.desc.2">+ %skill% 技能强度</string>
 	<string name="item.sets.disciples-arcana.desc.3">施法消耗降低 %cost%% </string>
 
 	<string name="item.sets.spheres-of-power.name">魔力宝珠</string>
-	<string name="item.sets.spheres-of-power.desc.1">小连杀新星</string>
-	<string name="item.sets.spheres-of-power.desc.2">连杀新星</string>
-	<string name="item.sets.spheres-of-power.desc.3">大连杀新星</string>
+	<string name="item.sets.spheres-of-power.desc.1">1级连杀新星</string>
+	<string name="item.sets.spheres-of-power.desc.2">2级连杀新星</string>
+	<string name="item.sets.spheres-of-power.desc.3">3级连杀新星</string>
 
-	<string name="item.sets.tricksters-ensemble.name">魔术师诡计</string>
+	<string name="item.sets.tricksters-ensemble.name">幻灵协律</string>
 	<string name="item.sets.tricksters-ensemble.desc.1">闪避时获得移动速度加成</string>
 	<string name="item.sets.tricksters-ensemble.desc.2">+ %chance%% 闪避</string>
 	<string name="item.sets.tricksters-ensemble.desc.3">闪避时触发连击效果</string>
 
-	<string name="item.sets.magic-missile.name">巫师套装</string>
-	<string name="item.sets.magic-missile.desc.1">使用技能时放出一个魔法飞弹.</string>
-	<string name="item.sets.magic-missile.desc.2">使用技能时放出%num%个魔法飞弹.</string>
+	<string name="item.sets.magic-missile.name">巫师入门套件</string>
+	<string name="item.sets.magic-missile.desc.1">使用技能时放出 1 个魔法飞弹.</string>
+	<string name="item.sets.magic-missile.desc.2">使用技能时放出 %num% 个魔法飞弹.</string>
 
 	<string name="item.sets.curios-collection.name">金玉满堂</string>
 	<string name="item.sets.curios-collection.desc">%stats% 生命与法力上限.\n%power% 普通攻击与技能伤害. \n%armor% 护甲 与 魔抗.</string>
@@ -2303,12 +2303,12 @@
 	<string name="drink.elemental-bruiser.desc">%pos%% 技能加成.\n%neg%% 技能消耗法力.</string>
 
 	<string name="drink.miners-delight.name">矿工挚爱</string>
-	<string name="drink.miners-delight.desc">%pos%% 矿石获取速率率.\n%neg%% 金币获取速率.</string>
+	<string name="drink.miners-delight.desc">%pos%% 矿石获取效率.\n%neg%% 金币获取效率.</string>
 
 	<string name="drink.last-stand.name">背水一战</string>
 	<string name="drink.last-stand.desc">+%pos%% 造成的伤害，原地不动时收到的伤害-50% .\n%neg%% 移动速度.</string>
 
-	<string name="drink.the-last-sin.name">恶名昭著</string>
+	<string name="drink.the-last-sin.name">罪不容诛</string>
 	<string name="drink.the-last-sin.desc">%pos%% 技能暴击伤害\n%neg% 法力回复率.</string>
 
 
@@ -2319,7 +2319,7 @@
 	<string name="drink.crimson-death.name">致命深红</string>
 	<string name="drink.crimson-death.desc">%pos%% 普攻和技能吸血.\n移动时损失生命.</string>
 
-	<string name="drink.hammer-time.name">以身作锤 </string>
+	<string name="drink.hammer-time.name">以身作锤</string>
 	<string name="drink.hammer-time.desc">%pos% 普攻伤害.\n%neg%% 护甲.</string>
 
 	<string name="drink.incendiary-demise.name">怒火中烧</string>

--- a/chinese/Chinese.lang
+++ b/chinese/Chinese.lang
@@ -2055,7 +2055,7 @@
 	<string name="item.seal-of-the-martyr.desc">每损失 1% 生命就增加 1% 普攻伤害.</string>
 
 	<string name="item.shaftlocke-pickaxe.name">矿井之镐</string>
-	<string name="item.shaftlocke-pickaxe.desc">+ %chance%% 矿石拾取效率.</string>
+	<string name="item.shaftlocke-pickaxe.desc">%chance%% 矿石拾取效率.</string>
 
 	<string name="item.spiked-boots.name">针刺铁靴</string>
 	<string name="item.spiked-boots.desc">触碰敌人时对其造成 %dmg% 点物理伤害.</string>

--- a/chinese/Chinese.lang
+++ b/chinese/Chinese.lang
@@ -2443,7 +2443,7 @@
 	<string name="fountain.effect.no_wells.description">泉水都不能使用.</string>
 
 	<string name="fountain.effect.no_shops.name">公休假日</string>
-	<string name="fountain.effect.no_shops.description">没有商店.</string>
+	<string name="fountain.effect.no_shops.description">关卡内没有商店.</string>
 
 	<string name="fountain.effect.no_ore.name">枯竭矿脉</string>
 	<string name="fountain.effect.no_ore.description">不会生成矿石.</string>

--- a/chinese/Chinese.lang
+++ b/chinese/Chinese.lang
@@ -2348,7 +2348,7 @@
 	<!-- GOOD -->
 
 
-	<string name="fountain.effect.bigger_levels.name">广阔楼层</string>
+	<string name="fountain.effect.bigger_levels.name">板块扩张</string>
 	<string name="fountain.effect.bigger_levels.description">每层楼的地图都变大.</string>
 
 	<string name="fountain.effect.glass_walks.name">玻璃路径</string>
@@ -2357,26 +2357,26 @@
 	<string name="fountain.effect.more_chest_rooms.name">宝藏狩猎</string>
 	<string name="fountain.effect.more_chest_rooms.description">有机会生成额外的宝箱房.</string>
 
-	<string name="fountain.effect.amazing_pickups.name">高级食品</string>
+	<string name="fountain.effect.amazing_pickups.name">山珍海味</string>
 	<string name="fountain.effect.amazing_pickups.description">生命和魔法拾取物发挥出额外500%的效果.</string>
 
-	<string name="fountain.effect.infinite_wells.name">无限泉水</string>
+	<string name="fountain.effect.infinite_wells.name">不竭之泉</string>
 	<string name="fountain.effect.infinite_wells.description">泉水的使用没有次数限制.</string>
 
 	<string name="fountain.effect.keep_all_gold.name">离岸账户</string>
 	<string name="fountain.effect.keep_all_gold.description">合理避税.</string>
 
-	<string name="fountain.effect.more_shop_items.name">充盈商店</string>
+	<string name="fountain.effect.more_shop_items.name">品目繁多</string>
 	<string name="fountain.effect.more_shop_items.description">商店的待售物品增加 2 个.</string>
 
-	<string name="fountain.effect.reduced_trap_damage.name">温和陷阱</string>
+	<string name="fountain.effect.reduced_trap_damage.name">温柔陷阱</string>
 	<string name="fountain.effect.reduced_trap_damage.description">陷阱造成的伤害降低50%.</string>
 
 	<string name="fountain.effect.better_loot.name">优质猎获</string>
 	<string name="fountain.effect.better_loot.description">有机会获得稀有度更高的战利品</string>
 
 	<string name="fountain.effect.no_towers.name">崩塌塔楼</string>
-	<string name="fountain.effect.no_towers.description">所有塔楼都被摧毁.</string>
+	<string name="fountain.effect.no_towers.description">所有塔楼类建筑都被摧毁.</string>
 
 	<string name="fountain.effect.no_pathway_traps.name">安全走廊</string>
 	<string name="fountain.effect.no_pathway_traps.description">走廊上的所有陷阱都被禁用.</string>
@@ -2385,18 +2385,18 @@
 	<string name="fountain.effect.no_spawners.description">所有生物巢穴都被摧毁.</string>
 
 	<string name="fountain.effect.ace_key.name">冠军钥匙</string>
-	<string name="fountain.effect.ace_key.description">得到一把红钥匙.</string>
+	<string name="fountain.effect.ace_key.description">得到一把Ace钥匙.</string>
 
-	<string name="fountain.effect.less_great_threat.name">少有危机</string>
-	<string name="fountain.effect.less_great_threat.description">严重的威胁变得更少见.</string>
+	<string name="fountain.effect.less_great_threat.name">罕有危机</string>
+	<string name="fountain.effect.less_great_threat.description">关卡时间限制惩罚变得很少见.</string>
 
 	<string name="fountain.effect.more_shrines.name">神秘指引</string>
-	<string name="fountain.effect.more_shrines.description">更有机会找到石碑.</string>
+	<string name="fountain.effect.more_shrines.description">生成更多的石碑.</string>
 
-	<string name="fountain.effect.more_imps.name">大量礼物</string>
-	<string name="fountain.effect.more_imps.description">更有机会找到恶魔.</string>
+	<string name="fountain.effect.more_imps.name">宾客如云</string>
+	<string name="fountain.effect.more_imps.description">送礼物的小恶魔变得更常见.</string>
 
-	<string name="fountain.effect.faster_enemies.name">敏捷对手</string>
+	<string name="fountain.effect.faster_enemies.name">机敏之敌</string>
 	<string name="fountain.effect.faster_enemies.description">敌人的移动速度提高50%.</string>
 
 	<string name="fountain.effect.minibosses_everywhere.name">工头监工</string>
@@ -2406,7 +2406,7 @@
 	<!-- BAD -->
 
 
-	<string name="fountain.effect.more_enemies.name">敌军增援</string>
+	<string name="fountain.effect.more_enemies.name">超生大队</string>
 	<string name="fountain.effect.more_enemies.description">更多敌人.</string>
 
 	<string name="fountain.effect.no_prison_button.name">钥匙被锁</string>
@@ -2415,22 +2415,22 @@
 	<string name="fountain.effect.more_elites.name">精锐增援</string>
 	<string name="fountain.effect.more_elites.description">更多精英敌人.</string>
 
-	<string name="fountain.effect.bad_pickups.name">垃圾食品</string>
+	<string name="fountain.effect.bad_pickups.name">餐风饮露</string>
 	<string name="fountain.effect.bad_pickups.description">生命和魔法拾取物只有50%的效果.</string>
 
-	<string name="fountain.effect.shitty_items.name">破烂道具</string>
+	<string name="fountain.effect.shitty_items.name">废铜烂铁</string>
 	<string name="fountain.effect.shitty_items.description">有小几率捡到一文不值的道具.</string>
 
-	<string name="fountain.effect.random_earthquakes.name">大地崩塌</string>
+	<string name="fountain.effect.random_earthquakes.name">山崩地裂</string>
 	<string name="fountain.effect.random_earthquakes.description">会发生随机的地震.</string>
 
 	<string name="fountain.effect.enemy_invasion.name">敌军入侵</string>
 	<string name="fountain.effect.enemy_invasion.description"></string>
 
-	<string name="fountain.effect.no_dropped_loot.name">两袖清风</string>
+	<string name="fountain.effect.no_dropped_loot.name">一文不名</string>
 	<string name="fountain.effect.no_dropped_loot.description">敌人不会掉落任何战利品.</string>
 
-	<string name="fountain.effect.no_secrets.name">裂缝无缝</string>
+	<string name="fountain.effect.no_secrets.name">严丝合缝</string>
 	<string name="fountain.effect.no_secrets.description">不会生成隐藏房间.</string>
 
 	<string name="fountain.effect.potion_confuse.name">辛辣药剂</string>
@@ -2440,10 +2440,10 @@
 	<string name="fountain.effect.container_bombs.description">容器里面会有更多的炸弹.</string>
 
 	<string name="fountain.effect.no_wells.name">干涸泉眼</string>
-	<string name="fountain.effect.no_wells.description">泉水都不能用.</string>
+	<string name="fountain.effect.no_wells.description">泉水都不能使用.</string>
 
-	<string name="fountain.effect.no_shops.name">公休假期</string>
-	<string name="fountain.effect.no_shops.description">没有在反派城堡里做生意的商人.</string>
+	<string name="fountain.effect.no_shops.name">公休假日</string>
+	<string name="fountain.effect.no_shops.description">没有商店.</string>
 
 	<string name="fountain.effect.no_ore.name">枯竭矿脉</string>
 	<string name="fountain.effect.no_ore.description">不会生成矿石.</string>
@@ -2455,7 +2455,7 @@
 	<string name="fountain.effect.1_hp.description">你的基础生命被设为1.</string>
 
 	<string name="fountain.effect.more_great_threat.name">无情危机</string>
-	<string name="fountain.effect.more_great_threat.description">严重的威胁变得很常见.</string>
+	<string name="fountain.effect.more_great_threat.description">关卡时间限制惩罚变得很频繁.</string>
 
 	<string name="fountain.effect.more_potion_charges.name">大号药瓶</string>
 	<string name="fountain.effect.more_potion_charges.description">药剂充能数+2.</string>


### PR DESCRIPTION
修复矿酒2个率和矿镐2个加号的问题
变更连杀新星描述使各等级描述对偶
变更火舌名称以与霜印对偶
进行了一些考证后的修改，如deciple特指信徒，无法引申为学者；start kit强调入门；regalia为专用名词，特指王者华服；ensemble多义项皆指向协奏等
此外有个别文字修改，都是出于对偶性考虑